### PR TITLE
Initial implementation of ContinuationLocal

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # continuation-local-storage-jvm
 
 This is a common implementation of continuation-local storage for the JVM.
-It is based on Twitter's com.twitter.util.Local, but this is a Java port
+It is based on Twitter's [`com.twitter.util.Local`](https://github.com/twitter/util/blob/master/util-core/src/main/scala/com/twitter/util/Local.scala), but this is a Java port
 without any external dependencies (notably; no dependency on Scala).
 
 The ContinuationLocal can be used for any data that should be persisted in
@@ -11,7 +11,7 @@ implementations.
 ## Usage example
 
 ```java
-import com.github.distributivetracing.ContinuationLocal
+import com.github.distributedtracing.ContinuationLocal;
 
 public final class MyProgram {
     private static final ContinuationLocal<Integer> userId
@@ -32,7 +32,7 @@ public final class MyProgram {
 
 - The value of `com.twitter.util.Local<T>` is of type `scala.Option<T>`,
   where `Some(value)` holds the value, while `None` indicates that the
-  value is absent. In `com.github.distributivetracing.ContinuationLocal<T>`,
+  value is absent. In `com.github.distributedtracing.ContinuationLocal<T>`,
   the value is not an Option, instead being a nullable of type `T`.
 - In `com.twitter.util.Local` the inner storage mechanism is a `ThreadLocal`,
   while in `ContinuationLocal`, it is a `InheritableThreadLocal`. This means

--- a/README.md
+++ b/README.md
@@ -1,2 +1,46 @@
 # continuation-local-storage-jvm
-A common JVM implementation of continuation-local storage
+
+This is a common implementation of continuation-local storage for the JVM.
+It is based on Twitter's com.twitter.util.Local, but this is a Java port
+without any external dependencies (notably; no dependency on Scala).
+
+The ContinuationLocal can be used for any data that should be persisted in
+a continuation scope, but is especially useful for various monitoring and tracing
+implementations.
+
+## Usage example
+
+```java
+import com.github.distributivetracing.ContinuationLocal
+
+public final class MyProgram {
+    private static final ContinuationLocal<Integer> userId
+      = new ContinuationLocal<Integer>();
+
+    public static void main(String[] args) {
+        userId.set(123);
+        printUserId();
+    }
+
+    private static void printUserId() {
+        System.out.println(userId.get());
+    }
+}
+```
+
+## Design differences between com.twitter.util.Local and ContinuationLocal:
+
+- The value of `com.twitter.util.Local<T>` is of type `scala.Option<T>`,
+  where `Some(value)` holds the value, while `None` indicates that the
+  value is absent. In `com.github.distributivetracing.ContinuationLocal<T>`,
+  the value is not an Option, instead being a nullable of type `T`.
+- In `com.twitter.util.Local` the inner storage mechanism is a `ThreadLocal`,
+  while in `ContinuationLocal`, it is a `InheritableThreadLocal`. This means
+  that a value that would not be passed on in `com.twitter.util.Local` will be
+  in a `ContinuationLocal`, in case a new thread is started in the same
+  context as the `ContinuationLocal` was set.
+- `com.twitter.util.Local`'s `update` method is not included. The similar
+  method `set` should instead be used. `update` in `c.t.u.Local` uses `Option`
+  types, while `set` in `ContinuationLocal` deals with nullable values directly.
+- `com.twitter.util.Local`'s (static) `letClear` function has been renamed to
+  `letAllClear` to avoid a naming collision with the non-static method `letClear`.

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,69 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.sonatype.oss</groupId>
+        <artifactId>oss-parent</artifactId>
+        <version>7</version>
+    </parent>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <groupId>com.github.distributedtracing</groupId>
+    <artifactId>continuation-local-storage</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <packaging>jar</packaging>
+
+    <name>continuation-local-storage</name>
+    <url>https://github.com/DistributedTracing/continuation-local-storage-jvm</url>
+
+    <description>
+        This is a Java port of Twitter's com.twitter.util.Local. The purpose of
+        ContinuationLocal is to be able to pass state implicitly between continuations;
+        much like a ThreadLocal, but one that also works in thread pools and event loops.
+    </description>
+
+    <licenses>
+        <license>
+            <name>The Apache Software License, Version 2.0</name>
+            <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+            <distribution>repo</distribution>
+        </license>
+    </licenses>
+
+    <developers>
+        <developer>
+            <id>eirslett</id>
+            <name>Eirik Sletteberg</name>
+            <email>eiriksletteberg@gmail.com</email>
+        </developer>
+    </developers>
+
+    <dependencies>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.12</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-compiler-plugin</artifactId>
+                    <version>3.1</version>
+                    <configuration>
+                        <source>1.6</source>
+                        <target>1.6</target>
+                    </configuration>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+    </build>
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -52,6 +52,29 @@
     </dependencies>
 
     <build>
+        <plugins>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>animal-sniffer-maven-plugin</artifactId>
+                <version>1.14</version>
+                <executions>
+                    <execution>
+                        <phase>test</phase>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <signature>
+                        <groupId>org.codehaus.mojo.signature</groupId>
+                        <artifactId>java16</artifactId>
+                        <version>1.1</version>
+                    </signature>
+                </configuration>
+            </plugin>
+        </plugins>
+        
         <pluginManagement>
             <plugins>
                 <plugin>

--- a/src/main/java/com/github/distributedtracing/ContinuationLocal.java
+++ b/src/main/java/com/github/distributedtracing/ContinuationLocal.java
@@ -1,0 +1,170 @@
+package com.github.distributedtracing;
+
+public final class ContinuationLocal<T> {
+    private static InheritableThreadLocal<Object[]> localCtx =
+            new InheritableThreadLocal<Object[]>();
+    private static volatile int size = 0;
+
+    /**
+     * Return a snapshot of the current ContinuationLocal state.
+     */
+    public static Object[] save() {
+        return localCtx.get();
+    }
+
+    /**
+     * Restore the ContinuationLocal state to a given set of values.
+     */
+    public static void restore(Object[] saved) {
+        localCtx.set(saved);
+    }
+
+    private static synchronized int add() {
+        size += 1;
+        return size - 1;
+    }
+
+    private static void set(int i, Object v) {
+        assert i < size;
+        Object[] ctx = localCtx.get();
+
+        if(ctx == null) {
+            ctx = new Object[size];
+        } else {
+            Object[] oldCtx = ctx;
+            ctx = new Object[size];
+            System.arraycopy(oldCtx, 0, ctx, 0, oldCtx.length);
+        }
+
+        ctx[i] = v;
+        localCtx.set(ctx);
+    }
+
+    private static Object get(int i) {
+        Object[] ctx = localCtx.get();
+        if(ctx == null || ctx.length <= i) {
+            return null;
+        }
+
+        return ctx[i];
+    }
+
+    private static void clear(int i) {
+        set(i, null);
+    }
+
+    /**
+     * Clear all locals in the current context.
+     */
+    private static void clearAll() {
+        localCtx.set(null);
+    }
+
+    /**
+     * Execute a block with the given ContinuationLocals,
+     * restoring current values upon completion.
+     */
+    public static <U> U let(Object[] ctx, Producer<U> f) {
+        Object[] saved = save();
+        restore(ctx);
+        U result;
+        try {
+            result = f.apply();
+        } finally {
+            restore(saved);
+        }
+        return result;
+    }
+
+    /**
+     * Execute a block with all ContinuationLocals clear, restoring
+     * current values upon completion.
+     */
+    public static <U> U letAllClear(Producer<U> f) {
+        return ContinuationLocal.let(null, f);
+    }
+
+    /**
+     * Convert a Producer&lt;R&gt; into another producer of the same
+     * type whose ContinuationLocal context is saved when calling `closed`
+     * and restored upon invocation.
+     */
+    public static <R> Producer<R> closed(final Producer<R> fn) {
+        final Object[] closure = ContinuationLocal.save();
+        return new Producer<R>() {
+            public R apply() {
+                Object[] save = ContinuationLocal.save();
+                ContinuationLocal.restore(closure);
+                R result;
+                try {
+                    result = fn.apply();
+                } finally {
+                    ContinuationLocal.restore(save);
+                }
+                return result;
+            }
+        };
+    }
+
+    private final int me = add();
+
+    /**
+     * Update the ContinuationLocal with the given value.
+     */
+    public void set(T value) {
+        set(me, value);
+    }
+
+    /**
+     * Get the ContinuationLocal's value.
+     */
+    public T get() {
+        return (T)get(me);
+    }
+
+    /**
+     * Alias for get()
+     */
+    public T apply() {
+        return get();
+    }
+
+    /**
+     * Execute a block with a specific ContinuationLocal value,
+     * restoring the current state upon completion.
+     */
+    public <U> U let(T value, Producer<U> f) {
+        T saved = get();
+        set(value);
+        U result;
+        try {
+            result = f.apply();
+        } finally {
+            set(saved);
+        }
+        return result;
+    }
+
+    /**
+     * Execute a block with the ContinuationLocal cleared, restoring
+     * the current state upon completion.
+     */
+    public <U> U letClear(Producer<U> f) {
+        T saved = get();
+        clear();
+        U result;
+        try {
+            result = f.apply();
+        } finally {
+            set(saved);
+        }
+        return result;
+    }
+
+    /**
+     * Clear the ContinuationLocal's value. Other ContinuationLocal's are not modified.
+     */
+    public void clear() {
+        ContinuationLocal.clear(me);
+    }
+}

--- a/src/main/java/com/github/distributedtracing/ContinuationLocalExecutorService.java
+++ b/src/main/java/com/github/distributedtracing/ContinuationLocalExecutorService.java
@@ -1,0 +1,115 @@
+package com.github.distributedtracing;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+public final class ContinuationLocalExecutorService implements ExecutorService {
+    private ExecutorService es;
+
+    private ContinuationLocalExecutorService(ExecutorService es) {
+        this.es = es;
+    }
+
+    public static ContinuationLocalExecutorService wrap(ExecutorService inner) {
+        return new ContinuationLocalExecutorService(inner);
+    }
+
+    public void shutdown() {
+        es.shutdown();
+    }
+
+    public List<Runnable> shutdownNow() {
+        return es.shutdownNow();
+    }
+
+    public boolean isShutdown() {
+        return es.isShutdown();
+    }
+
+    public boolean isTerminated() {
+        return es.isTerminated();
+    }
+
+    public boolean awaitTermination(long timeout, TimeUnit unit) throws InterruptedException {
+        return es.awaitTermination(timeout, unit);
+    }
+
+    public <T> Future<T> submit(Callable<T> task) {
+        return es.submit(wrapCallable(task));
+    }
+
+    public <T> Future<T> submit(Runnable task, T result) {
+        return es.submit(wrapRunnable(task), result);
+    }
+
+    public Future<?> submit(Runnable task) {
+        return es.submit(wrapRunnable(task));
+    }
+
+    public <T> List<Future<T>> invokeAll(Collection<? extends Callable<T>> tasks) throws InterruptedException {
+        return es.invokeAll(wrapCollection(tasks));
+    }
+
+    public <T> List<Future<T>> invokeAll(Collection<? extends Callable<T>> tasks, long timeout, TimeUnit unit) throws InterruptedException {
+        return es.invokeAll(wrapCollection(tasks), timeout, unit);
+    }
+
+    public <T> T invokeAny(Collection<? extends Callable<T>> tasks) throws InterruptedException, ExecutionException {
+        return es.invokeAny(wrapCollection(tasks));
+    }
+
+    public <T> T invokeAny(Collection<? extends Callable<T>> tasks, long timeout, TimeUnit unit) throws InterruptedException, ExecutionException, TimeoutException {
+        return es.invokeAny(wrapCollection(tasks), timeout, unit);
+    }
+
+    public void execute(final Runnable command) {
+        es.execute(wrapRunnable(command));
+    }
+
+    private <T> Collection<? extends Callable<T>> wrapCollection(Collection<? extends Callable<T>> callables) {
+        Collection<Callable<T>> wrapped = new ArrayList<Callable<T>>(callables.size());
+        for(Callable<T> callable : callables) {
+            wrapped.add(wrapCallable(callable));
+        }
+        return wrapped;
+    }
+
+    private Runnable wrapRunnable(final Runnable command) {
+        final Object[] saved = ContinuationLocal.save();
+        return new Runnable() {
+            public void run() {
+                Object[] ctx = ContinuationLocal.save();
+                ContinuationLocal.restore(saved);
+                try {
+                    command.run();
+                } finally {
+                    ContinuationLocal.restore(ctx);
+                }
+            }
+        };
+    }
+
+    private <T> Callable<T> wrapCallable(final Callable<T> callable) {
+        final Object[] saved = ContinuationLocal.save();
+        return new Callable<T>() {
+            public T call() throws Exception {
+                Object[] ctx = ContinuationLocal.save();
+                ContinuationLocal.restore(saved);
+                T result;
+                try {
+                    result = callable.call();
+                } finally {
+                    ContinuationLocal.restore(ctx);
+                }
+                return result;
+            }
+        };
+    }
+}

--- a/src/main/java/com/github/distributedtracing/Producer.java
+++ b/src/main/java/com/github/distributedtracing/Producer.java
@@ -1,0 +1,9 @@
+package com.github.distributedtracing;
+
+/**
+ * A FunctionalInterface, but compatible with
+ * earlier Java versions.
+ */
+public interface Producer<R> {
+    R apply();
+}

--- a/src/test/java/com/github/distributedtracing/ContinuationLocalExecutorServiceTest.java
+++ b/src/test/java/com/github/distributedtracing/ContinuationLocalExecutorServiceTest.java
@@ -1,0 +1,65 @@
+package com.github.distributedtracing;
+
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
+import java.util.concurrent.ThreadFactory;
+
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+public class ContinuationLocalExecutorServiceTest {
+    @Test
+    public void submit_task() throws ExecutionException, InterruptedException {
+        // Set up a thread pool that has been tweaked, so that every thread that is started
+        // clears its ContinuationLocal state. That way, we can verify that our wrap() method
+        // builds a thread pool where the ContinuationLocal state is restored befure every task.
+        final ContinuationLocalExecutorService service = ContinuationLocalExecutorService.wrap(
+                new ScheduledThreadPoolExecutor(8, new ClearContinuationLocalThreadFactory()));
+
+        final ContinuationLocal<Integer> value = new ContinuationLocal<Integer>();
+        value.set(257);
+
+        final boolean[] valueHasBeenOverwritten = new boolean[]{false};
+        final long threadId = Thread.currentThread().getId();
+
+        Future<Integer> futureInt = service.submit(new Callable<Integer>() {
+            public Integer call() throws Exception {
+                Thread.sleep(10);
+                assert valueHasBeenOverwritten[0];
+                assert threadId != Thread.currentThread().getId();
+                return value.get();
+            }
+        });
+
+        value.set(200);
+        valueHasBeenOverwritten[0] = true;
+
+        int result = futureInt.get();
+
+        assertThat(result, is(257));
+        assertThat(value.get(), is(200));
+    }
+
+    private static Runnable withClear(final Runnable r) {
+        return new Runnable() {
+            public void run() {
+                ContinuationLocal.letAllClear(new Producer<Object>() {
+                    public Object apply() {
+                        r.run();
+                        return null;
+                    }
+                });
+            }
+        };
+    }
+
+    private static final class ClearContinuationLocalThreadFactory implements ThreadFactory {
+        public Thread newThread(Runnable r) {
+            return new Thread(withClear(r));
+        }
+    }
+}

--- a/src/test/java/com/github/distributedtracing/ContinuationLocalTest.java
+++ b/src/test/java/com/github/distributedtracing/ContinuationLocalTest.java
@@ -1,0 +1,195 @@
+package com.github.distributedtracing;
+
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.junit.Assert.assertThat;
+
+public final class ContinuationLocalTest {
+    @Test
+    public void should_be_undefined_by_default() {
+        ContinuationLocal<Integer> local = new ContinuationLocal<Integer>();
+        assertThat(local.get(), is(nullValue()));
+    }
+
+    @Test
+    public void should_hold_on_to_values() {
+        ContinuationLocal<Integer> local = new ContinuationLocal<Integer>();
+        local.set(123);
+        assertThat(local.get(), is(123));
+    }
+
+    @Test
+    public void should_have_a_per_thread_definition() throws InterruptedException {
+        final ContinuationLocal<Integer> local = new ContinuationLocal<Integer>();
+        final Integer[] threadValue = new Integer[1];
+
+        local.set(123);
+
+        Thread t = new Thread() {
+            @Override
+            public void run() {
+                assertThat(local.get(), is(123));
+                local.set(333);
+                threadValue[0] = local.get();
+            }
+        };
+
+        t.start();
+        t.join();
+
+        assertThat(local.get(), is(123));
+        assertThat(threadValue[0], is(333));
+    }
+
+    @Test
+    public void should_maintain_value_definitions_when_other_continuation_locals_change() {
+        ContinuationLocal<Integer> l0 = new ContinuationLocal<Integer>();
+        l0.set(123);
+        Object[] save0 = ContinuationLocal.save();
+        ContinuationLocal<Integer> l1 = new ContinuationLocal<Integer>();
+        assertThat(l0.get(), is(123));
+        l1.set(333);
+        assertThat(l1.get(), is(333));
+
+        Object[] save1 = ContinuationLocal.save();
+        ContinuationLocal.restore(save0);
+        assertThat(l0.get(), is(123));
+        assertThat(l1.get(), is(nullValue()));
+
+        ContinuationLocal.restore(save1);
+        assertThat(l0.get(), is(123));
+        assertThat(l1.get(), is(333));
+    }
+
+    @Test
+    public void restore_should_restore_saved_values() {
+        ContinuationLocal<Integer> local = new ContinuationLocal<Integer>();
+        local.set(123);
+        Object[] saved = ContinuationLocal.save();
+        local.set(321);
+
+        ContinuationLocal.restore(saved);
+        assertThat(local.get(), is(123));
+    }
+
+    @Test
+    public void let_should_set_locals_and_restore_previous_value() {
+        final ContinuationLocal<Integer> l1 = new ContinuationLocal<Integer>();
+        final ContinuationLocal<Integer> l2 = new ContinuationLocal<Integer>();
+        l1.set(1);
+        l2.set(2);
+        Object[] ctx = ContinuationLocal.save();
+        l1.set(2);
+        l2.set(4);
+        final int[] executeCount = {0};
+
+        ContinuationLocal.let(ctx, new Producer<Object>() {
+            public Object apply() {
+                assertThat(l1.get(), is(1));
+                assertThat(l2.get(), is(2));
+                executeCount[0] += 1;
+                return null;
+            }
+        });
+
+        assertThat(l1.get(), is(2));
+        assertThat(l2.get(), is(4));
+        assertThat(executeCount[0], is(1));
+    }
+
+    @Test
+    public void letAllClear_should_clear_all_locals_and_restore_previous_value() {
+        final ContinuationLocal<Integer> l1 = new ContinuationLocal<Integer>();
+        final ContinuationLocal<Integer> l2 = new ContinuationLocal<Integer>();
+        l1.set(1);
+        l2.set(2);
+
+        ContinuationLocal.letAllClear(new Producer<Object>() {
+            public Object apply() {
+                assertThat(l1.get(), is(nullValue()));
+                assertThat(l2.get(), is(nullValue()));
+                return null;
+            }
+        });
+
+        assertThat(l1.get(), is(1));
+        assertThat(l2.get(), is(2));
+    }
+
+    @Test
+    public void restore_should_unset_undefined_variables_when_restoring() {
+        ContinuationLocal<Integer> local = new ContinuationLocal<Integer>();
+        Object[] saved = ContinuationLocal.save();
+        local.set(123);
+        ContinuationLocal.restore(saved);
+
+        assertThat(local.get(), is(nullValue()));
+    }
+
+    @Test
+    public void restore_should_not_restore_cleared_variables() {
+        ContinuationLocal<Integer> local = new ContinuationLocal<Integer>();
+        local.set(123);
+        ContinuationLocal.save(); // to trigger caching
+        local.clear();
+        ContinuationLocal.restore(ContinuationLocal.save());
+        assertThat(local.get(), is(nullValue()));
+    }
+
+    @Test
+    public void let_should_scope_with_a_value_and_restore_previous_value() {
+        final ContinuationLocal<Integer> local = new ContinuationLocal<Integer>();
+        local.set(123);
+        local.let(321, new Producer<Object>() {
+            public Object apply() {
+                assertThat(local.get(), is(321));
+                return null;
+            }
+        });
+        assertThat(local.get(), is(123));
+    }
+
+    @Test
+    public void letClear_should_clear_ContinuationLocal_and_restore_previous_value() {
+        final ContinuationLocal<Integer> local = new ContinuationLocal<Integer>();
+        local.set(123);
+        local.letClear(new Producer<Object>() {
+            public Object apply() {
+                assertThat(local.get(), is(nullValue()));
+                return null;
+            }
+        });
+        assertThat(local.get(), is(123));
+    }
+
+    @Test
+    public void clear_should_make_a_copy_when_clearing() {
+        ContinuationLocal<Integer> l = new ContinuationLocal<Integer>();
+        l.set(1);
+        Object[] save0 = ContinuationLocal.save();
+        l.clear();
+        assertThat(l.get(), is(nullValue()));
+        ContinuationLocal.restore(save0);
+        assertThat(l.get(), is(1));
+    }
+
+    @Test
+    public void closed() {
+        final ContinuationLocal<Integer> l = new ContinuationLocal<Integer>();
+        l.set(1);
+        Producer<Integer> adder = new Producer<Integer>() {
+            public Integer apply() {
+                int rv = 100 + l.get();
+                l.set(10000);
+                return rv;
+            }
+        };
+        Producer<Integer> fn = ContinuationLocal.closed(adder);
+        l.set(100);
+        assertThat(fn.apply(), is(101));
+        assertThat(l.get(), is(100));
+        assertThat(fn.apply(), is(101));
+    }
+}


### PR DESCRIPTION
> **Initial implementation of ContinuationLocal**
> The implementation is a direct port of com.twitter.util.Local:
> 
> https://github.com/twitter/util/blob/fe29be6ce62d27611ddfe94fdc9e9ec294375330/util-core/src/main/scala/com/twitter/util/Local.scala
> https://github.com/twitter/util/blob/fe29be6ce62d27611ddfe94fdc9e9ec294375330/util-core/src/test/scala/com/twitter/util/LocalTest.scala
> 
> An ExecutorService wrapper is also provided, meant to wrap thread
> pools so that the ContinuationLocal state is passed on. This
> implementation is inspired by BraveExecutorService and FuturePool:
> 
> https://github.com/kristofa/brave/blob/df55efd5653bccdb4736fd63413f10772a5bb5e2/brave-core/src/main/java/com/github/kristofa/brave/BraveExecutorService.java
> https://github.com/twitter/util/blob/fe29be6ce62d27611ddfe94fdc9e9ec294375330/util-core/src/main/scala/com/twitter/util/FuturePool.scala

Here's a (more or less) direct port of com.twitter.util.Local to Java, with only a few differences.
This ContinuationLocal needs mainstream adoption in order to work (every library that's dealing with threads and/or events needs to support it), so we have to get it right.

Any comments from the Twitter guys who wrote this (in Scala) in the first place?
@adriancole @mosesn @mariusae @evnm ?
